### PR TITLE
Hotfix `0.11.8`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeus-network/zeus-stack-sdk",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "SDK for Zeus Network's Bitcoin-to-zBTC cross-chain protocol on Solana",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/src/zpl/liquidity-management/instruction.ts
+++ b/src/zpl/liquidity-management/instruction.ts
@@ -24,7 +24,7 @@ class LiquidityManagementInstructions {
     solanaPubkey: PublicKey,
     assetMint: PublicKey,
     reserveSettingPda: PublicKey,
-    receiverAta: PublicKey
+    receiver: PublicKey
   ) {
     const vaultSettingPda =
       this.pdas.deriveVaultSettingAddress(reserveSettingPda);
@@ -35,6 +35,12 @@ class LiquidityManagementInstructions {
     const vaultAta = getAssociatedTokenAddressSync(
       assetMint,
       splTokenVaultAuthorityPda,
+      true
+    );
+
+    const receiverAta = getAssociatedTokenAddressSync(
+      assetMint,
+      receiver,
       true
     );
 
@@ -59,6 +65,7 @@ class LiquidityManagementInstructions {
           isSigner: true,
           isWritable: true,
         },
+        { pubkey: receiver, isSigner: false, isWritable: false },
         { pubkey: receiverAta, isSigner: false, isWritable: true },
         { pubkey: positionPda, isSigner: false, isWritable: true },
         { pubkey: vaultSettingPda, isSigner: false, isWritable: false },

--- a/src/zpl/two-way-peg/account.ts
+++ b/src/zpl/two-way-peg/account.ts
@@ -13,6 +13,8 @@ import {
   HotReserveBucketSchema,
   TwoWayPegConfiguration,
   TwoWayPegConfigurationSchema,
+  UserSetting,
+  UserSettingSchema,
 } from "./types";
 
 class TwoWayPegAccounts {
@@ -131,6 +133,27 @@ class TwoWayPegAccounts {
     );
 
     return entityDerivedReserveAddresses;
+  }
+
+  async getUserSetting(solanaPubkey: PublicKey): Promise<UserSetting[]> {
+    const filters = [
+      createDiscriminatorFilter("two-way-peg:user-setting"),
+      {
+        memcmp: {
+          offset: 8,
+          bytes: solanaPubkey.toBase58(),
+        },
+      },
+    ];
+
+    const UserSetting = await getDeserializedAccounts(
+      this.connection,
+      this.programId,
+      filters,
+      UserSettingSchema
+    );
+
+    return UserSetting;
   }
 }
 

--- a/src/zpl/two-way-peg/instruction.ts
+++ b/src/zpl/two-way-peg/instruction.ts
@@ -215,6 +215,8 @@ class TwoWayPegInstructions {
       currentSlot
     );
 
+    const userSettingPda = this.pdas.deriveUserSetting(solanaPubkey);
+
     const instructionData = Buffer.alloc(
       AddWithdrawalRequestWithAddressTypeSchema.span
     );
@@ -242,8 +244,9 @@ class TwoWayPegInstructions {
           isWritable: false,
         },
         { pubkey: configurationPda, isSigner: false, isWritable: false },
-        { pubkey: reserveSettingPda, isSigner: false, isWritable: false },
+        { pubkey: reserveSettingPda, isSigner: false, isWritable: true },
         { pubkey: vaultSettingPda, isSigner: false, isWritable: false },
+        { pubkey: userSettingPda, isSigner: false, isWritable: true },
         { pubkey: withdrawalRequestPda, isSigner: false, isWritable: true },
         { pubkey: interactionPda, isSigner: false, isWritable: true },
         { pubkey: positionPda, isSigner: false, isWritable: true },

--- a/src/zpl/two-way-peg/instruction.ts
+++ b/src/zpl/two-way-peg/instruction.ts
@@ -163,7 +163,7 @@ class TwoWayPegInstructions {
           isWritable: false,
         },
         { pubkey: configurationPda, isSigner: false, isWritable: false },
-        { pubkey: reserveSettingPda, isSigner: false, isWritable: false },
+        { pubkey: reserveSettingPda, isSigner: false, isWritable: true },
         { pubkey: vaultSettingPda, isSigner: false, isWritable: false },
         { pubkey: withdrawalRequestPda, isSigner: false, isWritable: true },
         { pubkey: interactionPda, isSigner: false, isWritable: true },

--- a/src/zpl/two-way-peg/pda.ts
+++ b/src/zpl/two-way-peg/pda.ts
@@ -76,6 +76,14 @@ class TwoWayPegPdas {
     )[0];
     return interactionPda;
   }
+
+  deriveUserSetting(owner: PublicKey): PublicKey {
+    const userSettingPda = PublicKey.findProgramAddressSync(
+      [Buffer.from("user-setting"), owner.toBuffer()],
+      this.programId
+    )[0];
+    return userSettingPda;
+  }
 }
 
 export default TwoWayPegPdas;

--- a/src/zpl/two-way-peg/types.ts
+++ b/src/zpl/two-way-peg/types.ts
@@ -38,6 +38,8 @@ export interface TwoWayPegConfiguration {
   bucketReactivationFeeAmount: BN;
   withdrawalFeeAmount: BN;
   minerFeeRate: number;
+  maxUserWithdrawalQuota: BN;
+  userWithdrawalWindow: BN;
 }
 
 export const TwoWayPegConfigurationSchema: Structure<TwoWayPegConfiguration> =
@@ -55,6 +57,8 @@ export const TwoWayPegConfigurationSchema: Structure<TwoWayPegConfiguration> =
     borsh.u64("bucketReactivationFeeAmount"),
     borsh.u64("withdrawalFeeAmount"),
     borsh.u32("minerFeeRate"),
+    borsh.u64("maxUserWithdrawalQuota"),
+    borsh.i64("userWithdrawalWindow"),
   ]);
 
 export interface ColdReserveBucket {
@@ -181,6 +185,24 @@ export const EntityDerivedReserveAddressSchema: Structure<EntityDerivedReserveAd
     borsh.i64("expiredAt"),
     borsh.option(borsh.publicKey(), "reserveUser"),
   ]);
+
+export interface UserSetting {
+  owner: PublicKey;
+  createdAt: BN;
+  updatedAt: BN;
+  withdrawalWindowStartedAt: BN;
+  accumulatedWithdrawalAmount: BN;
+  hasUnlimitedWithdrawalQuota: boolean;
+}
+
+export const UserSettingSchema: Structure<UserSetting> = borsh.struct([
+  borsh.publicKey("owner"),
+  borsh.i64("createdAt"),
+  borsh.i64("updatedAt"),
+  borsh.i64("withdrawalWindowStartedAt"),
+  borsh.u64("accumulatedWithdrawalAmount"),
+  borsh.bool("hasUnlimitedWithdrawalQuota"),
+]);
 
 /* ========================================== */
 


### PR DESCRIPTION
## Summary

- Added user setting functionality with withdrawal quota management  
- Updated TwoWayPegConfiguration to include user withdrawal quota and window settings
- Enhanced liquidity management instruction to support receiver transfers
- Made reserve setting writable in AddWithdrawalRequest operations
- Bumped version to 0.11.8

## Changes

- **User Setting Feature**: Added UserSetting type, schema, PDA derivation, and account fetching
- **Configuration Updates**: Added maxUserWithdrawalQuota and userWithdrawalWindow to TwoWayPegConfiguration  
- **Instruction Improvements**:
  - Made reserve setting writable in withdrawal request instructions
  - Updated liquidity management to handle receiver parameter properly
- **Version Bump**: Updated package.json to version 0.11.8

🤖 Generated with [Claude Code](https://claude.ai/code)