### PR TITLE
docs: fix trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,4 @@ This project is licensed under the MIT License - see the [LICENSE](./LICENSE) fi
 
 - [Zeus Network](https://zeusnetwork.xyz)
 - [GitHub Issues](https://github.com/ZeusNetworkHQ/zeus-stack-sdk-js/issues)
+


### PR DESCRIPTION
Minor cleanup — removed trailing whitespace in README.md